### PR TITLE
The character sequence $APP_VERSION was being used instead of the value of $APP_VERSION

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
           release_name: $APP_VERSION
           body: |
             Automated release
-            $APP_VERSION
+            echo "$APP_VERSION"
           draft: false
           prerelease: false
 


### PR DESCRIPTION
# What and why?

When this first merged to main, the release was tagged with the literal string "$APP_VERSION" instead of the value of the `$APP_VERSION` environment variable. Echoing the value in the GHA will hopefully resolve this. 

# How to test?

We're trying to replicate the following in the GHA run: script

```
➜  export APP_VERSION=1.1.1
➜  echo "$APP_VERSION"
➜  1.1.1
```

Merge a new release to main and ensure the tag and release of the actual value is used, and not the string literal