### PR TITLE
Add WIF service account to benchmark app

### DIFF
--- a/_infra/helm/ras-rm-benchmark/Chart.yaml
+++ b/_infra/helm/ras-rm-benchmark/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.6
+version: 1.0.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.6
+appVersion: 1.0.7

--- a/_infra/helm/ras-rm-benchmark/templates/job.yaml
+++ b/_infra/helm/ras-rm-benchmark/templates/job.yaml
@@ -8,6 +8,11 @@ spec:
     metadata:
       name: "{{ .Chart.Name }}"
     spec:
+      serviceAccountName: ras-rm-k8s-services
+      imagePullSecrets:
+        - name: gar-secret
+      nodeSelector:
+        iam.gke.io/gke-metadata-server-enabled: "true"
       restartPolicy: "OnFailure"
       containers:
         - name: "{{ .Chart.Name }}"


### PR DESCRIPTION
# What and why?
Allows the Benchmark app to use the WIF service account and the correct permission `storage.admin`
# How to test?
Test with https://github.com/ONSdigital/ras-rm-terraform/pull/455
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1820